### PR TITLE
Add `MessageInterceptor` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,8 +543,10 @@ checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -623,6 +625,16 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "combine"
@@ -1553,7 +1565,7 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 1.3.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -2144,6 +2156,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "log2"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7d196b21fc84948f99055f1effc75e5a14fdccd31e9bf1f248d772a48dc132"
+dependencies = [
+ "chrono",
+ "colored",
+ "log",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,6 +2239,7 @@ dependencies = [
  "anyhow",
  "clap",
  "log",
+ "log2",
  "mcp-guardian-core",
  "tokio",
 ]
@@ -2936,12 +2960,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "thiserror 1.0.69",
- "toml 0.5.11",
+ "once_cell",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -3286,9 +3310,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -4326,15 +4350,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
@@ -4850,9 +4865,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5328,6 +5343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e376c75f4f43f44db463cf729e0d3acbf954d13e22c51e26e4c264b4ab545f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5458,9 +5482,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2494e4b3f44d8363eef79a8a75fc0649efb710eef65a66b5e688a5eb4afe678a"
+checksum = "cbddd8b6cb25d5d8ec1b23277b45299a98bfb220f1761ca11e186d5c702507f8"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -5485,7 +5509,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",
- "winnow 0.6.20",
+ "winnow 0.7.1",
  "xdg-home",
  "zbus_macros",
  "zbus_names",
@@ -5494,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445efc01929302aee95e2b25bbb62a301ea8a6369466e4278e58e7d1dfb23631"
+checksum = "dac404d48b4e9cf193c8b49589f3280ceca5ff63519e7e64f55b4cf9c47ce146"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -5509,13 +5533,13 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.1.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519629a3f80976d89c575895b05677cbc45eaf9f70d62a364d819ba646409cc8"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
- "winnow 0.6.20",
+ "winnow 0.7.1",
  "zvariant",
 ]
 
@@ -5591,24 +5615,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e6b9b5f1361de2d5e7d9fd1ee5f6f7fcb6060618a1f82f3472f58f2b8d4be9"
+checksum = "31c951c21879c6e1d46ac5adfc34f698fefb465d498cf4ac87545849bd71bb5a"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "static_assertions",
- "winnow 0.6.20",
+ "winnow 0.7.1",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573a8dd76961957108b10f7a45bac6ab1ea3e9b7fe01aff88325dc57bb8f5c8b"
+checksum = "9eeb539471af098d9e63faf428c71ac4cd4efe0b5baa3c8a6b991c5f2543b70e"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -5619,14 +5643,14 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd46446ea2a1f353bfda53e35f17633afa79f4fe290a611c94645c69fe96a50"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "static_assertions",
  "syn 2.0.97",
- "winnow 0.6.20",
+ "winnow 0.7.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["macros", "multipart"] }
 clap = { version = "4", features = ["cargo", "derive"] }
 confy = "0.6"
-env_logger = "0.10"
 dirs = "5"
 log = "0.4"
+log2 = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = { version = "0.26", features = ["derive"] }

--- a/mcp-guardian-core/src/dirs.rs
+++ b/mcp-guardian-core/src/dirs.rs
@@ -16,6 +16,7 @@ fn app_dir() -> Result<PathBuf> {
 #[allow(clippy::all)]
 #[derive(VariantArray)]
 pub enum AppSubDir {
+    Logs,
     MessageApprovals,
     MessageApprovalsPending,
     MessageApprovalsApproved,
@@ -25,6 +26,7 @@ pub enum AppSubDir {
 impl AppSubDir {
     pub fn path(&self) -> Result<PathBuf> {
         let path = match self {
+            Self::Logs => app_dir()?.join("logs"),
             Self::MessageApprovals => app_dir()?.join("message-approvals"),
             Self::MessageApprovalsPending => Self::MessageApprovals.path()?.join("pending"),
             Self::MessageApprovalsApproved => Self::MessageApprovals.path()?.join("approved"),

--- a/mcp-guardian-core/src/proxy/context.rs
+++ b/mcp-guardian-core/src/proxy/context.rs
@@ -1,8 +1,10 @@
-use crate::proxy::request_cache::RequestCache;
+use std::sync::Arc;
+
+use crate::proxy::message_interceptor::MessageInterceptor;
 
 pub struct Context {
     pub mcp_server_name: String,
     pub host_session_id: Option<String>,
     pub session_id: String,
-    pub request_cache: RequestCache,
+    pub message_interceptor: Arc<dyn MessageInterceptor>,
 }

--- a/mcp-guardian-core/src/proxy/message.rs
+++ b/mcp-guardian-core/src/proxy/message.rs
@@ -1,160 +1,29 @@
-use std::sync::Arc;
-
-use anyhow::{bail, Result};
 use serde_json::Value;
 
-use crate::proxy::{
-    context::Context,
-    message_approval::{request_approval, MessageDirection, MessageStatus},
-};
-
-pub async fn intercept_outbound_message(msg: Value, ctx: Arc<Context>) -> Result<Value> {
-    let Context {
-        mcp_server_name,
-        session_id,
-        request_cache,
-        ..
-    } = &*ctx;
-
-    let parsed_msg = parse_message(msg.clone())?;
-
-    #[allow(clippy::single_match)]
-    match parsed_msg {
-        RpcMessage::Request(_) => {
-            request_cache.store_request(msg.clone())?;
-
-            let id = match msg.get("id") {
-                Some(Value::Number(n)) => n.to_string(),
-                Some(Value::String(s)) => s.clone(),
-                _ => {
-                    bail!("Request without id: {msg}");
-                }
-            };
-            let Some(Value::String(method)) = msg.get("method") else {
-                bail!("Request without method: {msg}");
-            };
-
-            if method == "tools/call" {
-                let approval_id = format!("{session_id}_{id}");
-                let check_approval =
-                    request_approval(&approval_id, MessageDirection::Outbound, msg.clone()).await?;
-                loop {
-                    let status = check_approval();
-                    log::debug!("Request {status}: {id}");
-                    match status {
-                        MessageStatus::Pending => {
-                            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-                        }
-                        MessageStatus::Approved => {
-                            break;
-                        }
-                        MessageStatus::Denied | MessageStatus::Unknown => {
-                            return Ok(Value::Null);
-                        }
-                    }
-                }
-            }
-        }
-        _ => {}
-    }
-
-    log::debug!(
-        "{} | {} | Host --> MCP Guardian Proxy --> MCP Server: {}",
-        mcp_server_name,
-        parsed_msg.log_prefix(),
-        msg,
-    );
-
-    Ok(msg)
+#[derive(strum::Display, Clone, Copy, PartialEq)]
+pub enum MessageDirection {
+    #[strum(serialize = "outbound")]
+    Outbound,
+    #[strum(serialize = "inbound")]
+    Inbound,
 }
 
-pub async fn intercept_inbound_message(msg: Value, ctx: Arc<Context>) -> Result<Value> {
-    let Context {
-        mcp_server_name,
-        session_id,
-        request_cache,
-        ..
-    } = &*ctx;
-
-    let parsed_msg = parse_message(msg.clone())?;
-
-    #[allow(clippy::single_match)]
-    match parsed_msg {
-        RpcMessage::ResponseSuccess(_) => {
-            if let Some(id) = msg.get("id").cloned() {
-                if let Some(request) = request_cache.pop_request(&id)? {
-                    let id = match request.get("id") {
-                        Some(Value::Number(n)) => n.to_string(),
-                        Some(Value::String(s)) => s.clone(),
-                        _ => {
-                            bail!("Request without id: {msg}");
-                        }
-                    };
-                    let Some(Value::String(method)) = request.get("method") else {
-                        bail!("Request without method: {request}");
-                    };
-
-                    if method == "tools/call" {
-                        let approval_id = format!("{session_id}_{id}");
-                        let check_approval =
-                            request_approval(&approval_id, MessageDirection::Inbound, msg.clone())
-                                .await?;
-                        loop {
-                            let status = check_approval();
-                            log::debug!("Response {status}: {id}");
-                            match status {
-                                MessageStatus::Pending => {
-                                    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-                                }
-                                MessageStatus::Approved => {
-                                    break;
-                                }
-                                MessageStatus::Denied | MessageStatus::Unknown => {
-                                    return Ok(Value::Null);
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    log::error!("Response to unknown request (id={}): {}", id, msg);
-                }
-            } else {
-                log::error!("Response without id: {}", msg);
-            }
-        }
-        _ => {}
-    }
-
-    log::info!(
-        "{} | {} | Host <-- MCP Guardian Proxy <-- MCP Server: {}",
-        mcp_server_name,
-        parsed_msg.log_prefix(),
-        msg,
-    );
-
-    Ok(msg)
+#[derive(Clone, Copy, PartialEq)]
+pub enum MessageType {
+    Request,
+    ResponseSuccess,
+    ResponseFailure,
+    Notification,
+    Unknown,
 }
 
-fn parse_message(msg: Value) -> Result<RpcMessage> {
-    let jsonrpc = msg.get("jsonrpc").and_then(|id| id.as_str());
-    let id = msg.get("id");
-    let method = msg.get("method");
-    let params = msg.get("params");
-    let result = msg.get("result");
-    let error = msg.get("error");
-
-    let rpc_message = match (jsonrpc, id, method, params, result, error) {
-        (Some("2.0"), Some(_), Some(_), _, None, None) => RpcMessage::Request(msg),
-        (Some("2.0"), Some(_), None, None, Some(_), None) => RpcMessage::ResponseSuccess(msg),
-        (Some("2.0"), Some(_), None, None, None, Some(_)) => RpcMessage::EespsoneFailure(msg),
-        (Some("2.0"), None, Some(_), _, None, None) => RpcMessage::Notification(msg),
-        _ => RpcMessage::Unknown(msg),
-    };
-
-    Ok(rpc_message)
-}
-
-pub enum RpcMessage {
+// TODO: refactor to
+// pub struct Message {
+//     pub type_: MessageType,
+//     pub raw_msg: Value,
+// }
+#[derive(Clone)]
+pub enum Message {
     Request(Value),
     ResponseSuccess(Value),
     EespsoneFailure(Value),
@@ -162,25 +31,52 @@ pub enum RpcMessage {
     Unknown(Value),
 }
 
-impl RpcMessage {
+impl Message {
+    pub fn from_json(msg: Value) -> Message {
+        let jsonrpc = msg.get("jsonrpc").and_then(|id| id.as_str());
+        let id = msg.get("id");
+        let method = msg.get("method");
+        let params = msg.get("params");
+        let result = msg.get("result");
+        let error = msg.get("error");
+
+        match (jsonrpc, id, method, params, result, error) {
+            (Some("2.0"), Some(_), Some(_), _, None, None) => Message::Request(msg),
+            (Some("2.0"), Some(_), None, None, Some(_), None) => Message::ResponseSuccess(msg),
+            (Some("2.0"), Some(_), None, None, None, Some(_)) => Message::EespsoneFailure(msg),
+            (Some("2.0"), None, Some(_), _, None, None) => Message::Notification(msg),
+            _ => Message::Unknown(msg),
+        }
+    }
+
     pub fn log_prefix(&self) -> String {
         match self {
-            RpcMessage::Request(_) => "Request",
-            RpcMessage::ResponseSuccess(_) => "Response (Ok)",
-            RpcMessage::EespsoneFailure(_) => "Response (Err)",
-            RpcMessage::Notification(_) => "Notification",
-            RpcMessage::Unknown(_) => "Unknown",
+            Message::Request(_) => "Request",
+            Message::ResponseSuccess(_) => "Response (Ok)",
+            Message::EespsoneFailure(_) => "Response (Err)",
+            Message::Notification(_) => "Notification",
+            Message::Unknown(_) => "Unknown",
         }
         .to_string()
     }
 
     pub fn raw_msg(&self) -> &Value {
         match self {
-            RpcMessage::Request(msg) => msg,
-            RpcMessage::ResponseSuccess(msg) => msg,
-            RpcMessage::EespsoneFailure(msg) => msg,
-            RpcMessage::Notification(msg) => msg,
-            RpcMessage::Unknown(msg) => msg,
+            Message::Request(msg) => msg,
+            Message::ResponseSuccess(msg) => msg,
+            Message::EespsoneFailure(msg) => msg,
+            Message::Notification(msg) => msg,
+            Message::Unknown(msg) => msg,
+        }
+    }
+
+    pub fn type_(&self) -> MessageType {
+        match self {
+            Message::Request(_) => MessageType::Request,
+            Message::ResponseSuccess(_) => MessageType::ResponseSuccess,
+            Message::EespsoneFailure(_) => MessageType::ResponseFailure,
+            Message::Notification(_) => MessageType::Notification,
+            Message::Unknown(_) => MessageType::Unknown,
         }
     }
 }

--- a/mcp-guardian-core/src/proxy/message_approval.rs
+++ b/mcp-guardian-core/src/proxy/message_approval.rs
@@ -3,17 +3,10 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
 
-use crate::dirs::AppSubDir::{
-    MessageApprovalsApproved, MessageApprovalsDenied, MessageApprovalsPending,
+use crate::{
+    dirs::AppSubDir::{MessageApprovalsApproved, MessageApprovalsDenied, MessageApprovalsPending},
+    proxy::message::MessageDirection,
 };
-
-#[derive(strum::Display)]
-pub enum MessageDirection {
-    #[strum(serialize = "inbound")]
-    Inbound,
-    #[strum(serialize = "outbound")]
-    Outbound,
-}
 
 #[derive(strum::Display)]
 pub enum MessageStatus {

--- a/mcp-guardian-core/src/proxy/message_interceptor.rs
+++ b/mcp-guardian-core/src/proxy/message_interceptor.rs
@@ -1,0 +1,41 @@
+pub mod chain;
+pub mod filter;
+pub mod manual_approval;
+pub mod message_log;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::proxy::message::{
+    Message, MessageDirection,
+    MessageDirection::{Inbound, Outbound},
+};
+
+#[derive(Clone)]
+pub enum MessageInterceptorAction {
+    Send(Message),
+    Drop,
+}
+
+#[async_trait]
+pub trait MessageInterceptor: Send + Sync {
+    async fn intercept_message(
+        &self,
+        direction: MessageDirection,
+        message: Message,
+    ) -> Result<MessageInterceptorAction>;
+
+    async fn intercept_outbound_message(
+        &self,
+        message: Message,
+    ) -> Result<MessageInterceptorAction> {
+        self.intercept_message(Outbound, message).await
+    }
+
+    async fn intercept_inbound_message(
+        &self,
+        message: Message,
+    ) -> Result<MessageInterceptorAction> {
+        self.intercept_message(Inbound, message).await
+    }
+}

--- a/mcp-guardian-core/src/proxy/message_interceptor/chain.rs
+++ b/mcp-guardian-core/src/proxy/message_interceptor/chain.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::proxy::{
+    message::{Message, MessageDirection},
+    message_interceptor::{
+        MessageInterceptor, MessageInterceptorAction,
+        MessageInterceptorAction::{Drop, Send},
+    },
+};
+pub struct ChainInterceptor {
+    pub interceptors: Vec<Arc<dyn MessageInterceptor>>,
+}
+
+impl ChainInterceptor {
+    pub fn new(interceptors: Vec<Arc<dyn MessageInterceptor>>) -> Self {
+        Self { interceptors }
+    }
+}
+
+#[async_trait]
+impl MessageInterceptor for ChainInterceptor {
+    async fn intercept_message(
+        &self,
+        direction: MessageDirection,
+        message: Message,
+    ) -> Result<MessageInterceptorAction> {
+        let Self { interceptors } = self;
+
+        let mut message = message;
+
+        for interceptor in interceptors {
+            match interceptor.intercept_message(direction, message).await? {
+                Send(new_message) => message = new_message,
+                Drop => return Ok(Drop),
+            }
+        }
+
+        Ok(Send(message))
+    }
+}

--- a/mcp-guardian-core/src/proxy/message_interceptor/filter.rs
+++ b/mcp-guardian-core/src/proxy/message_interceptor/filter.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use serde_json::Value;
+use MessageInterceptorAction::{Drop, Send};
+
+use crate::proxy::{
+    message::{Message, MessageDirection, MessageType},
+    message_interceptor::{MessageInterceptor, MessageInterceptorAction},
+    request_cache::RequestCache,
+};
+
+pub enum FilterLogic {
+    // Include messages that match the specified direction
+    Direction(MessageDirection),
+    // Include messages that match the specified message type
+    MessageType(MessageType),
+    // Include request and response messages with the specified method call
+    RequestMethod(String),
+    // Include messages that match all of the specified filters
+    And(Vec<FilterLogic>),
+    // Include messages that match any of the specified filters
+    Or(Vec<FilterLogic>),
+    // Exclude messages that match the specified filter
+    Not(Box<FilterLogic>),
+}
+
+impl FilterLogic {
+    pub fn matches(
+        &self,
+        direction: MessageDirection,
+        message: &Message,
+        request_cache: &RequestCache,
+    ) -> bool {
+        match self {
+            FilterLogic::Direction(d) => direction == *d,
+            FilterLogic::MessageType(t) => message.type_() == *t,
+            FilterLogic::RequestMethod(m) => match message.type_() {
+                MessageType::Request => {
+                    message.raw_msg().get("method") == Some(&Value::String(m.clone()))
+                }
+                MessageType::ResponseSuccess | MessageType::ResponseFailure => {
+                    let Some(id) = message.raw_msg().get("id").cloned() else {
+                        return false;
+                    };
+
+                    if let Ok(Some(request)) = request_cache.pop_request(&id) {
+                        request.get("method") == Some(&Value::String(m.clone()))
+                    } else {
+                        false
+                    }
+                }
+                _ => false,
+            },
+            FilterLogic::And(filters) => filters
+                .iter()
+                .all(|f| f.matches(direction, message, request_cache)),
+            FilterLogic::Or(filters) => filters
+                .iter()
+                .any(|f| f.matches(direction, message, request_cache)),
+            FilterLogic::Not(f) => !f.matches(direction, message, request_cache),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum FilterAction {
+    Send,
+    Drop,
+    Intercept(Arc<dyn MessageInterceptor + std::marker::Send + Sync>),
+}
+
+pub struct Filter {
+    pub logic: FilterLogic,
+    pub match_action: FilterAction,
+    pub non_match_action: FilterAction,
+}
+
+impl Filter {
+    pub fn new(
+        logic: FilterLogic,
+        match_action: FilterAction,
+        non_match_action: FilterAction,
+    ) -> Self {
+        Self {
+            logic,
+            match_action,
+            non_match_action,
+        }
+    }
+}
+
+pub struct FilterInterceptor {
+    pub filter: Filter,
+    pub request_cache: RequestCache,
+}
+
+impl FilterInterceptor {
+    pub fn new(filter: Filter) -> Self {
+        let request_cache = RequestCache::new();
+
+        Self {
+            filter,
+            request_cache,
+        }
+    }
+}
+
+#[async_trait]
+impl MessageInterceptor for FilterInterceptor {
+    async fn intercept_message(
+        &self,
+        direction: MessageDirection,
+        message: Message,
+    ) -> Result<MessageInterceptorAction> {
+        let Self {
+            filter,
+            request_cache,
+        } = self;
+
+        // cache request message for lookup during interception of corresponding response
+        if message.type_() == MessageType::Request {
+            request_cache.store_request(message.raw_msg().clone())?;
+        }
+
+        let action = if filter.logic.matches(direction, &message, request_cache) {
+            &filter.match_action
+        } else {
+            &filter.non_match_action
+        };
+
+        // pop request message from cache after corresponding response messages if it wasn't already popped during filter traversal
+        if matches!(
+            message.type_(),
+            MessageType::ResponseSuccess | MessageType::ResponseFailure
+        ) {
+            let Some(id) = message.raw_msg().get("id").cloned() else {
+                bail!("Request does not have an id.");
+            };
+            let _ = request_cache.pop_request(&id)?;
+        }
+
+        match action {
+            FilterAction::Send => Ok(Send(message)),
+            FilterAction::Drop => Ok(Drop),
+            FilterAction::Intercept(interceptor) => {
+                interceptor.intercept_message(direction, message).await
+            }
+        }
+    }
+}

--- a/mcp-guardian-core/src/proxy/message_interceptor/manual_approval.rs
+++ b/mcp-guardian-core/src/proxy/message_interceptor/manual_approval.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::time::{sleep, Duration};
+use uuid::Uuid;
+use MessageInterceptorAction::{Drop, Send};
+
+use crate::proxy::{
+    message::{Message, MessageDirection},
+    message_approval::{request_approval, MessageStatus},
+    message_interceptor::{MessageInterceptor, MessageInterceptorAction},
+};
+
+pub struct ManualApprovalInterceptor {
+    pub mcp_server_name: String,
+}
+
+impl ManualApprovalInterceptor {
+    pub fn new(mcp_server_name: String) -> Self {
+        Self { mcp_server_name }
+    }
+}
+
+#[async_trait]
+impl MessageInterceptor for ManualApprovalInterceptor {
+    async fn intercept_message(
+        &self,
+        direction: MessageDirection,
+        message: Message,
+    ) -> Result<MessageInterceptorAction> {
+        let Self { mcp_server_name } = self;
+
+        let approval_id = format!("{mcp_server_name}_{direction}_{}", Uuid::new_v4());
+
+        let check_approval =
+            request_approval(&approval_id, direction, message.raw_msg().clone()).await?;
+
+        loop {
+            match check_approval() {
+                MessageStatus::Pending => {
+                    sleep(Duration::from_millis(1000)).await;
+                }
+                MessageStatus::Approved => {
+                    return Ok(Send(message));
+                }
+                MessageStatus::Denied | MessageStatus::Unknown => {
+                    return Ok(Drop);
+                }
+            }
+        }
+    }
+}

--- a/mcp-guardian-core/src/proxy/message_interceptor/message_log.rs
+++ b/mcp-guardian-core/src/proxy/message_interceptor/message_log.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use log::{log, Level};
+
+use crate::proxy::{
+    message::{Message, MessageDirection},
+    message_interceptor::{
+        MessageInterceptor, MessageInterceptorAction, MessageInterceptorAction::Send,
+    },
+};
+pub struct MessageLogInterceptor {
+    pub log_level: Level,
+    pub mcp_server_name: String,
+}
+
+impl MessageLogInterceptor {
+    pub fn new(log_level: Level, mcp_server_name: String) -> Self {
+        Self {
+            log_level,
+            mcp_server_name,
+        }
+    }
+}
+
+#[async_trait]
+impl MessageInterceptor for MessageLogInterceptor {
+    async fn intercept_message(
+        &self,
+        direction: MessageDirection,
+        message: Message,
+    ) -> Result<MessageInterceptorAction> {
+        let Self {
+            log_level,
+            mcp_server_name,
+        } = self;
+
+        let log_prefix = message.log_prefix();
+        let raw_msg = message.raw_msg();
+
+        log!(
+            *log_level,
+            "{direction} | {mcp_server_name} | {log_prefix} | {raw_msg}"
+        );
+
+        Ok(Send(message))
+    }
+}

--- a/mcp-guardian-proxy/Cargo.toml
+++ b/mcp-guardian-proxy/Cargo.toml
@@ -10,4 +10,5 @@ mcp-guardian-core = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 log = { workspace = true }
+log2  = { workspace = true }
 tokio = { workspace = true }

--- a/mcp-guardian-proxy/Justfile
+++ b/mcp-guardian-proxy/Justfile
@@ -21,6 +21,9 @@ build-release: _bin
 clean:
     cargo clean
 
+inspect +CMD:
+    npx @modelcontextprotocol/inspector sh -c "mcp-guardian-proxy -- {{CMD}}"
+
 _bin:
     mkdir -p ../_build/bin
  

--- a/mcp-guardian-proxy/src/main.rs
+++ b/mcp-guardian-proxy/src/main.rs
@@ -1,6 +1,17 @@
+use std::sync::Arc;
+
 use anyhow::{bail, Result};
 use clap::Parser;
-use mcp_guardian_core::proxy::proxy_mcp_server;
+use mcp_guardian_core::proxy::{
+    message_interceptor::{
+        chain::ChainInterceptor,
+        filter::{Filter, FilterAction, FilterInterceptor, FilterLogic},
+        manual_approval::ManualApprovalInterceptor,
+        message_log::MessageLogInterceptor,
+        MessageInterceptor,
+    },
+    proxy_mcp_server,
+};
 use mcp_guardian_proxy::cli;
 
 #[tokio::main]
@@ -13,15 +24,44 @@ async fn main() -> Result<()> {
 
     mcp_guardian_core::dirs::create_all_dirs()?;
 
+    let log_file = mcp_guardian_core::dirs::AppSubDir::Logs
+        .path()?
+        .join("mcp-guardian-proxy.log");
+
+    log2::open(log_file.to_string_lossy().as_ref()).start();
+
     let [command, args @ ..] = &cmd[..] else {
         bail!("No MCP server command provided.");
     };
 
     let args = args.iter().map(String::as_str).collect::<Vec<_>>();
 
-    if let Err(e) = proxy_mcp_server(name, host_session_id, command, &args).await {
+    let proxy_interceptor = proxy_interceptor(name.clone().unwrap_or("unnamed".to_owned()));
+
+    if let Err(e) = proxy_mcp_server(name, host_session_id, command, &args, proxy_interceptor).await
+    {
         eprint!("Error starting MCP server: {e}");
     }
 
     Ok(())
+}
+
+fn proxy_interceptor(mcp_server_name: String) -> Arc<dyn MessageInterceptor> {
+    let log_all_messages = Arc::new(MessageLogInterceptor::new(
+        log::Level::Info,
+        mcp_server_name.clone(),
+    ));
+
+    let manually_approve_tool_calls = Arc::new(FilterInterceptor::new(Filter::new(
+        FilterLogic::RequestMethod("tools/call".to_owned()),
+        FilterAction::Intercept(Arc::new(ManualApprovalInterceptor::new(
+            mcp_server_name.clone(),
+        ))),
+        FilterAction::Send,
+    )));
+
+    Arc::new(ChainInterceptor::new(vec![
+        log_all_messages,
+        manually_approve_tool_calls,
+    ]))
 }


### PR DESCRIPTION
- Adds `MessageInterceptor` trait and some message interceptor implementations to `mcp_guardian_core`
- Changes `mcp_guardian_core::proxy::run_proxy_server` to use a message interceptor passed in by caller
- Updates `mcp-guardian-proxy` to build and pass in a message interceptor.