### PR TITLE
bundle all binaries with tauri bundle

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,18 @@ jobs:
       - name: Build `mcp-guardian-cli`
         run: cd mcp-guardian-cli && cargo build --release
 
+      - name: Prepare non-tauri binaries for tauri bundling
+        if: matrix.platform != 'windows-2022'
+        run: |
+          cp target/release/mcp-guardian-proxy mcp-guardian/src-tauri/
+          cp target/release/mcp-guardian-cli mcp-guardian/src-tauri/
+
+      - name: Prepare non-tauri binaries for tauri bundling
+        if: matrix.platform == 'windows-2022'
+        run: |
+          copy target\release\mcp-guardian-proxy.exe mcp-guardian\src-tauri\
+          copy target\release\mcp-guardian-cli.exe mcp-guardian\src-tauri\
+
       - name: Build `mcp-guardian`
         run: cd mcp-guardian && yarn && yarn tauri build
 

--- a/mcp-guardian/src-tauri/mcp-guardian-bundle-readme.md
+++ b/mcp-guardian/src-tauri/mcp-guardian-bundle-readme.md
@@ -1,0 +1,7 @@
+# Files
+
+`mcp-guardian/.exe`: MCP Guardian GUI Application
+
+`mcp-guardian-cli/.exe`: MCP Guardian CLI Application
+
+`mcp-guardian-proxy/.exe`: MCP Server Proxy

--- a/mcp-guardian/src-tauri/tauri.conf.json
+++ b/mcp-guardian/src-tauri/tauri.conf.json
@@ -24,6 +24,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": [
+      "mcp-guardian-*"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Adds `mcp-guardian-proxy` and `mcp-guardian-cli` to macOS and Windows release bundles.

This is a bit hacky with the glob matcher in tauri.conf.json but is simpler for now than breaking out multiple configurations.